### PR TITLE
Bump down required version of peer dependency Relay

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "dependencies": {},
   "devDependencies": {},
   "peerDependencies": {
-    "react-relay": "^0.4.0"
+    "react-relay": "^0.2.0"
   }
 }


### PR DESCRIPTION
This decorator will work with all versions of Relay released so far, so this PR allows people stuck with older versions get in on the decorating fun.
